### PR TITLE
MacOS support for M1-M3

### DIFF
--- a/kasm_ec2_desktops/README.md
+++ b/kasm_ec2_desktops/README.md
@@ -5,6 +5,7 @@ Go to Kasm version control folder, then run these commands.
     - brew install kreuzwerker/taps/m1-terraform-provider-helper
     - m1-terraform-provider-helper activate
     - m1-terraform-provider-helper install hashicorp/template -v v2.2.0
+    - NOTE: This version of Devops now supports Apple Silicon M1-M3 so some of these commands may not be necessary. Use at your own risk, any issues please contact the original authors J Mortensen, T Patil, and R Jaiswal. All following commands are the same as the original DevOps project.
 - Run a `terraform init` to initialize the project.
 - Run a `terraform plan` to see what resources will be created.
 - If the plan looks good, run `terraform apply` to create the Nginx configurations.
@@ -25,8 +26,8 @@ Run these commands to build EC2 instances
 Create an instance, perform tests, and then come back quickly and destroy. 
 
 ```bash
-teraform init
-teraform plan -var="instances_start=2"
+terraform init
+terraform plan -var="instances_start=2"
 terraform apply -var="instances_start=2"
 # ... test time ...
 terraform destroy
@@ -38,7 +39,7 @@ The remaining portion of this is trying to make a plan, apply the plan, and dest
 Option A plan - Create 1 instance starting at 5.  
 
 ```bash
-teraform init
+terraform init
 terraform plan -var="instances_start=5" -out=opA.tfplan
 terraform apply opA.tfplan
 ```
@@ -66,7 +67,7 @@ mkdir -p ~/projects
 cd ~/projects
 git clone https://github.com/nighthawkcoders/devOps.git dop1
 cd ~/projects/dop1/kasm
-teraform init
+terraform init
 terraform plan -var="instances_start=50" -out=plan.tfplan
 terraform apply plan.tfplan
 terraform show

--- a/kasm_ec2_desktops/ec2.tf
+++ b/kasm_ec2_desktops/ec2.tf
@@ -2,32 +2,32 @@
 
 # create AWS EC2 instances
 resource "aws_instance" "ec2_server" {
-  count = length(local.ec2_instances) # aws_instance iterator
+    count = length(local.ec2_instances) # aws_instance iterator
 
-  # assign Meta data
-  tags = {
-    Name   = local.ec2_instances[count.index]["ec2_Name"]  # Name tag for AWS console
-    Domain = local.ec2_instances[count.index]["ec2_Domain"]
-  }
-
-  # assign EC2 key-value properties
-  ami           = "ami-03f65b8614a860c29"  # ubuntu predefined image
-  instance_type = "t2.medium"
-  key_name      = "${var.key_pair}"
-
-  # assign EC2 storage properties
-  ebs_block_device {
-    device_name = "/dev/sda1"
-    volume_type = "gp3"
-    volume_size = 60
+    # assign Meta data
     tags = {
-      MountPoint = "/mnt/data"
+        Name   = local.ec2_instances[count.index]["ec2_Name"]  # Name tag for AWS console
+        Domain = local.ec2_instances[count.index]["ec2_Domain"]
     }
-  }
 
-  # create reference to a Security group, see security.tf
-  vpc_security_group_ids = [aws_security_group.web_sg.id]
+    # assign EC2 key-value properties
+    ami           = "ami-03f65b8614a860c29"  # ubuntu predefined image
+    instance_type = "t2.medium"
+    key_name      = "${var.key_pair}"
 
-  # file provision and assign System setup script, see ec2_install.sh.tpl
-  user_data = data.template_file.ec2_install[count.index].rendered
+    # assign EC2 storage properties
+    ebs_block_device {
+        device_name = "/dev/sda1"
+        volume_type = "gp3"
+        volume_size = 60
+        tags = {
+            MountPoint = "/mnt/data"
+        }
+    }
+
+    # create reference to a Security group, see security.tf
+    vpc_security_group_ids = [aws_security_group.web_sg.id]
+
+    # file provision and assign System setup script, see ec2_install.sh.tpl
+    user_data = element(local.ec2_install, count.index)
 }

--- a/kasm_ec2_desktops/main.tf
+++ b/kasm_ec2_desktops/main.tf
@@ -2,7 +2,7 @@
 
 # Oregon region
 provider "aws" {
-  region = "us-west-2"
+  region = "us-west-1"
 }
 
 # tool versions
@@ -30,14 +30,12 @@ locals {
 }
 
 # provision ec2 installation scripts
-data "template_file" "ec2_install" {
-  count = length(local.ec2_instances)
-  template = file("${path.module}/ec2_install.sh.tpl")
-
-  vars = {
-    SUBDOMAIN = local.ec2_instances[count.index]["ec2_Subdomain"]
-    DOMAIN    = local.ec2_instances[count.index]["ec2_Domain"]
-    EMAIL     = var.email
-  }
+locals {
+  ec2_install = [
+    for i in range(length(local.ec2_instances)) : templatefile("${path.module}/ec2_install.sh.tpl", {
+      SUBDOMAIN = local.ec2_instances[i]["ec2_Subdomain"]
+      DOMAIN    = local.ec2_instances[i]["ec2_Domain"]
+      EMAIL     = var.email
+    })
+  ]
 }
-


### PR DESCRIPTION
Modified the main.tf and the ec2.tf to allow for support of the newest M1 through M3 chips from Apple. This was made to get around the problem with hashicorp/template from Hashicorp's deprecation of further development of the M1 branch of template by using template_file() function from [Hashicorp](https://developer.hashicorp.com/terraform/language/functions/templatefile). Version v2.2.0 is no longer supported on darwin-amd64. Added acknowledgment of new updates to the M1-M3 code, and giving warning that my code is from a beginner. also fixing some typos in commands see lines 29, 30, 42, and 70.